### PR TITLE
ci(projects): Auto-Add Issues/PRs zum Projects v2 Board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,22 @@
+name: Add issues and PRs to Project
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+  pull_request:
+    types: [opened, edited, labeled, ready_for_review]
+
+jobs:
+  add-to-project:
+    if: github.event_name == 'issues' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to Project
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: ${{ secrets.PROJECTS_URL }}
+          github-token: ${{ secrets.PROJECTS_TOKEN }}
+          labeled: ''
+          # Optional: only include certain labels, leave empty to add all items
+          # labeled: feature,ui,gamification
+


### PR DESCRIPTION
Automatisiert die Zuordnung neu/aktualisierter Issues/PRs zum User-Project via actions/add-to-project. Benötigt Secrets: PROJECTS_URL, PROJECTS_TOKEN.