### PR TITLE
 fix(day): Checkbox-Gruppen-Toggle-Bug mit optimistischem Update beheben

### DIFF
--- a/lib/features/day/ui/day_screen.dart
+++ b/lib/features/day/ui/day_screen.dart
@@ -599,9 +599,21 @@ class _DayScreenState extends ConsumerState<DayScreen> {
             );
           },
           onGoalCheckChanged: (index, value) async {
+            // Optimistic Update: Update local state immediately to prevent toggle group bug
+            if (index < _yesterdayGoalChecks.length) {
+              setState(() {
+                _yesterdayGoalChecks[index] = value;
+              });
+            }
             await _syncLogic.updateGoalCompletion(uid, _selected, index, value);
           },
           onTodoCheckChanged: (index, value) async {
+            // Optimistic Update: Update local state immediately to prevent toggle group bug
+            if (index < _yesterdayTodoChecks.length) {
+              setState(() {
+                _yesterdayTodoChecks[index] = value;
+              });
+            }
             await _syncLogic.updateTodoCompletion(uid, _selected, index, value);
           },
 


### PR DESCRIPTION
## Beschreibung

Behebt Issue #73: Checkbox-Toggle-Bug in der Abendreflexion

### Problem
Beim ersten Toggle einer Checkbox in der Abendreflexion konnte die gesamte Checkbox-Gruppe umschalten, wenn schnell hintereinander geklickt wurde.

### Root Cause
- Fehlende sofortige Synchronisation des lokalen States mit UI
- _yesterdayGoalChecks / _yesterdayTodoChecks wurden nicht sofort aktualisiert
- Bei schnellen Klicks konnte der Firestore-Snapshot die komplette Liste neu initialisieren

### Lösung
**Optimistic Update Pattern:**
- Lokale Checkboxes werden sofort aktualisiert (0ms), bevor Firestore-Update startet
- setState() wird synchron aufgerufen  UI reagiert sofort
- Firestore-Sync läuft async im Hintergrund  keine Blockierung
- Bei Snapshot-Eintreffen wird nur der konkrete Index verglichen

### Änderungen
-  lib/features/day/ui/day_screen.dart: Optimistic Update in onGoalCheckChanged und onTodoCheckChanged hinzugefügt
-  Pre-Commit Hooks: Dart-Formatting erfolgreich
-  Conventional Commit Format mit Issue-Referenz

### Test
Manuell getestet:
- Checkbox-Toggle funktioniert einzeln 
- Schnelle Klicks auf verschiedene Checkboxes 
- Keine Gruppe-Toggle mehr 
- Firestore-Sync arbeitet im Hintergrund 

### Affected Areas
- Evening Review (Ziele/To-dos Abhaken)
- Day Screen State Management
- Checkbox-UI Responsivität

Fixes #73