### PR TITLE
refactor(screens): Settings & Week aufgeteilt (#71)

### DIFF
--- a/lib/features/settings/widgets/maintenance_tools.dart
+++ b/lib/features/settings/widgets/maintenance_tools.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../../../services/firestore_service.dart';
+import '../../../widgets/reflecto_button.dart';
+
+/// Wartungs-Tools: Planung deduplizieren
+class MaintenanceTools extends ConsumerStatefulWidget {
+  const MaintenanceTools({super.key});
+
+  @override
+  ConsumerState<MaintenanceTools> createState() => _MaintenanceToolsState();
+}
+
+class _MaintenanceToolsState extends ConsumerState<MaintenanceTools> {
+  bool _running = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final user = FirebaseAuth.instance.currentUser;
+    final uid = user?.uid;
+
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: ReflectoButton(
+        text: _running ? 'Bereinige...' : 'Planung deduplizieren',
+        icon: Icons.cleaning_services_outlined,
+        onPressed: (uid == null || _running)
+            ? null
+            : () async {
+                setState(() => _running = true);
+                try {
+                  final n = await FirestoreService().dedupeAllPlanningForUser(
+                    uid,
+                  );
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                        'Bereinigung abgeschlossen: $n Dokument(e) aktualisiert',
+                      ),
+                    ),
+                  );
+                } catch (e) {
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(
+                    context,
+                  ).showSnackBar(SnackBar(content: Text('Fehler: $e')));
+                } finally {
+                  if (mounted) setState(() => _running = false);
+                }
+              },
+      ),
+    );
+  }
+}

--- a/lib/features/settings/widgets/profile_section.dart
+++ b/lib/features/settings/widgets/profile_section.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../../../services/firestore_service.dart';
+import '../../../models/user_model.dart';
+import '../../../widgets/reflecto_button.dart';
+
+/// Profil-Bereich: Anzeigename bearbeiten und speichern
+class ProfileSection extends StatefulWidget {
+  const ProfileSection({super.key});
+
+  @override
+  State<ProfileSection> createState() => _ProfileSectionState();
+}
+
+class _ProfileSectionState extends State<ProfileSection> {
+  bool _loading = false;
+  final _nameCtrl = TextEditingController();
+  String? _email;
+
+  @override
+  void initState() {
+    super.initState();
+    final user = FirebaseAuth.instance.currentUser;
+    _email = user?.email;
+    _nameCtrl.text = user?.displayName ?? '';
+  }
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _saveProfile() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    final newName = _nameCtrl.text.trim();
+    if (newName.isEmpty) return;
+
+    setState(() => _loading = true);
+    try {
+      await user.updateDisplayName(newName);
+      await FirestoreService().saveUserData(
+        AppUser(
+          uid: user.uid,
+          displayName: newName,
+          email: user.email,
+          photoUrl: user.photoURL,
+        ),
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Profil gespeichert')));
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Fehler beim Speichern: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TextField(
+          controller: _nameCtrl,
+          decoration: const InputDecoration(
+            labelText: 'Anzeigename',
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.all(Radius.circular(12)),
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        if (_email != null && _email!.isNotEmpty)
+          Text('E-Mail: $_email', style: const TextStyle(color: Colors.grey)),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: ReflectoButton(
+            text: _loading ? 'Speichern…' : 'Profil speichern',
+            icon: Icons.save_outlined,
+            onPressed: _loading ? null : _saveProfile,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/widgets/theme_section.dart
+++ b/lib/features/settings/widgets/theme_section.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../providers/settings_providers.dart';
+
+/// Theme-Auswahl-Widget: System / Hell / Dunkel
+class ThemeSection extends ConsumerWidget {
+  const ThemeSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mode = ref.watch(themeModeProvider);
+    void setMode(AppThemeMode m) => ref.read(themeModeProvider.notifier).set(m);
+
+    return SegmentedButton<AppThemeMode>(
+      segments: const [
+        ButtonSegment(
+          value: AppThemeMode.system,
+          label: Text('System'),
+          icon: Icon(Icons.settings_suggest_outlined),
+        ),
+        ButtonSegment(
+          value: AppThemeMode.light,
+          label: Text('Hell'),
+          icon: Icon(Icons.light_mode_outlined),
+        ),
+        ButtonSegment(
+          value: AppThemeMode.dark,
+          label: Text('Dunkel'),
+          icon: Icon(Icons.dark_mode_outlined),
+        ),
+      ],
+      selected: {mode},
+      onSelectionChanged: (set) {
+        final sel = set.first;
+        setMode(sel);
+      },
+    );
+  }
+}

--- a/lib/features/settings/widgets/version_info.dart
+++ b/lib/features/settings/widgets/version_info.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:intl/intl.dart';
+
+import '../../../utils/build_info.dart';
+
+/// Versions- und Build-Informationen
+class VersionInfo extends StatefulWidget {
+  const VersionInfo({super.key});
+
+  @override
+  State<VersionInfo> createState() => _VersionInfoState();
+}
+
+class _VersionInfoState extends State<VersionInfo> {
+  String? _version;
+  String? _buildInfo;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadVersion();
+  }
+
+  Future<void> _loadVersion() async {
+    final info = await PackageInfo.fromPlatform();
+    if (!mounted) return;
+
+    // Semantische Version aus pubspec
+    final version = info.version;
+    String displayTime = kBuildTime;
+    if (displayTime.isEmpty) {
+      displayTime = DateFormat('yyyy-MM-dd HH:mm').format(DateTime.now());
+    }
+
+    // Build-String zusammensetzen: buildNumber + channel + shortSha + time
+    final buildParts = <String>[
+      if (info.buildNumber.isNotEmpty && info.buildNumber != '0')
+        info.buildNumber,
+      if ((kBuildChannel).isNotEmpty) kBuildChannel else 'local',
+      if (shortGitSha().isNotEmpty) shortGitSha(),
+      displayTime,
+    ];
+    final build = buildParts.where((e) => e.isNotEmpty).join(' ');
+
+    setState(() {
+      _version = version;
+      _buildInfo = build;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [const Text('Version'), Text(_version ?? '…')],
+        ),
+        const SizedBox(height: 8),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [const Text('Build'), Text(_buildInfo ?? '')],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/week/logic/week_stats.dart
+++ b/lib/features/week/logic/week_stats.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+
+import '../../../models/journal_entry.dart';
+
+/// Aggregiert Statistiken über eine Woche (7 Tage).
+///
+/// Liefert Min/Max/Durchschnitt für Fokus, Energie, Zufriedenheit
+/// sowie einen Stimmungsverlauf (Mood Curve) für Sparkline.
+class WeekStats {
+  final double focusAvg;
+  final double energyAvg;
+  final double happinessAvg;
+  final int? focusMin;
+  final int? focusMax;
+  final int? energyMin;
+  final int? energyMax;
+  final int? happinessMin;
+  final int? happinessMax;
+  final List<int> moodCurve; // 7 Tage, 0-5
+
+  const WeekStats({
+    required this.focusAvg,
+    required this.energyAvg,
+    required this.happinessAvg,
+    this.focusMin,
+    this.focusMax,
+    this.energyMin,
+    this.energyMax,
+    this.happinessMin,
+    this.happinessMax,
+    required this.moodCurve,
+  });
+
+  /// Berechnet Statistiken aus einer Liste von Journal-Einträgen.
+  ///
+  /// [entries] müssen zu [range] passen (7 aufeinanderfolgende Tage).
+  factory WeekStats.aggregate(List<JournalEntry> entries, DateTimeRange range) {
+    int? minF, minE, minH, maxF, maxE, maxH;
+    double sumF = 0, sumE = 0, sumH = 0;
+    int cF = 0, cE = 0, cH = 0;
+
+    // Mood-Kurve für 7 Tage
+    final mood = List<int?>.filled(7, null);
+    final byId = {for (final e in entries) e.id: e};
+
+    for (var i = 0; i < 7; i++) {
+      final day = range.start.add(Duration(days: i));
+      final id =
+          '${day.year}-${day.month.toString().padLeft(2, '0')}-${day.day.toString().padLeft(2, '0')}';
+      final e = byId[id];
+
+      if (e != null) {
+        final f = e.ratingFocus;
+        final en = e.ratingEnergy;
+        final h = e.ratingHappiness;
+
+        if (f != null) {
+          sumF += f;
+          cF++;
+          minF = (minF == null) ? f : (f < minF ? f : minF);
+          maxF = (maxF == null) ? f : (f > maxF ? f : maxF);
+        }
+        if (en != null) {
+          sumE += en;
+          cE++;
+          minE = (minE == null) ? en : (en < minE ? en : minE);
+          maxE = (maxE == null) ? en : (en > maxE ? en : maxE);
+        }
+        if (h != null) {
+          sumH += h;
+          cH++;
+          minH = (minH == null) ? h : (h < minH ? h : minH);
+          maxH = (maxH == null) ? h : (h > maxH ? h : maxH);
+          mood[i] = h;
+        }
+      }
+    }
+
+    double avg(double s, int c) => c == 0 ? 0 : (s / c);
+
+    return WeekStats(
+      focusAvg: avg(sumF, cF),
+      energyAvg: avg(sumE, cE),
+      happinessAvg: avg(sumH, cH),
+      focusMin: minF,
+      focusMax: maxF,
+      energyMin: minE,
+      energyMax: maxE,
+      happinessMin: minH,
+      happinessMax: maxH,
+      moodCurve: mood.map((e) => e ?? 0).toList(),
+    );
+  }
+
+  /// Konvertiert die Statistik in eine Map (für JSON-Export).
+  Map<String, dynamic> toJson() {
+    return {
+      'focusAvg': focusAvg,
+      'energyAvg': energyAvg,
+      'happinessAvg': happinessAvg,
+      'focusMin': focusMin,
+      'energyMin': energyMin,
+      'happinessMin': happinessMin,
+      'focusMax': focusMax,
+      'energyMax': energyMax,
+      'happinessMax': happinessMax,
+      'moodCurve': moodCurve,
+    };
+  }
+}

--- a/lib/features/week/widgets/week_ai_analysis_card.dart
+++ b/lib/features/week/widgets/week_ai_analysis_card.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+
+import '../../../widgets/reflecto_card.dart';
+import '../../../widgets/reflecto_button.dart';
+import '../../../services/firestore_service.dart';
+import '../../../services/export_import_service.dart';
+
+/// KI-Auswertung/Notizen-Card: Textfeld für Import + Speichern-Button.
+class WeekAiAnalysisCard extends StatefulWidget {
+  final String uid;
+  final String weekId;
+  final Map<String, dynamic>? weeklyData;
+
+  const WeekAiAnalysisCard({
+    super.key,
+    required this.uid,
+    required this.weekId,
+    required this.weeklyData,
+  });
+
+  @override
+  State<WeekAiAnalysisCard> createState() => _WeekAiAnalysisCardState();
+}
+
+class _WeekAiAnalysisCardState extends State<WeekAiAnalysisCard> {
+  final _aiCtrl = TextEditingController();
+  final _svc = FirestoreService();
+  final _exportSvc = ExportImportService();
+
+  @override
+  void dispose() {
+    _aiCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final motto = widget.weeklyData?['motto'] as String?;
+    final summary = widget.weeklyData?['summaryText'] as String?;
+    final ai = widget.weeklyData?['aiAnalysis'];
+
+    return ReflectoCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'KI-Auswertung / Notizen',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          if (motto != null && motto.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(
+              'Motto: $motto',
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+          ],
+          if (summary != null && summary.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(summary),
+          ],
+          if (ai != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              'AI-Daten vorhanden',
+              style: TextStyle(color: Theme.of(context).colorScheme.secondary),
+            ),
+          ],
+          const SizedBox(height: 12),
+          TextField(
+            controller: _aiCtrl,
+            maxLines: null,
+            decoration: const InputDecoration(
+              hintText: 'KI-Auswertung hier einfügen (Text oder JSON)…',
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.all(Radius.circular(12)),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: ReflectoButton(
+                  text: 'Importieren & Speichern',
+                  onPressed: () async {
+                    final messenger = ScaffoldMessenger.of(context);
+                    final input = _aiCtrl.text.trim();
+                    if (input.isEmpty) return;
+
+                    final parsed = _exportSvc.tryParseAiAnalysis(input);
+                    final toSave = parsed != null && parsed.containsKey('text')
+                        ? {'aiAnalysisText': parsed['text']}
+                        : {'aiAnalysis': parsed};
+
+                    await _svc.saveWeeklyReflection(
+                      widget.uid,
+                      widget.weekId,
+                      toSave,
+                    );
+
+                    if (!mounted) return;
+                    messenger.showSnackBar(
+                      const SnackBar(content: Text('Auswertung gespeichert')),
+                    );
+                    _aiCtrl.clear();
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/week/widgets/week_export_card.dart
+++ b/lib/features/week/widgets/week_export_card.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../widgets/reflecto_card.dart';
+import '../../../widgets/reflecto_button.dart';
+import '../../../services/export_import_service.dart';
+
+/// Export-Card: Buttons für JSON- und Markdown-Export in Zwischenablage.
+class WeekExportCard extends StatelessWidget {
+  final Map<String, dynamic> jsonData;
+
+  const WeekExportCard({super.key, required this.jsonData});
+
+  @override
+  Widget build(BuildContext context) {
+    final exportSvc = ExportImportService();
+
+    return ReflectoCard(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Export', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: ReflectoButton(
+                  text: 'JSON kopieren',
+                  onPressed: () async {
+                    final messenger = ScaffoldMessenger.of(context);
+                    await Clipboard.setData(
+                      ClipboardData(text: jsonEncode(jsonData)),
+                    );
+                    if (!context.mounted) return;
+                    messenger.showSnackBar(
+                      const SnackBar(content: Text('JSON in Zwischenablage')),
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ReflectoButton(
+                  text: 'Markdown kopieren',
+                  onPressed: () async {
+                    final messenger = ScaffoldMessenger.of(context);
+                    final md = exportSvc.buildMarkdownFromJson(jsonData);
+                    await Clipboard.setData(ClipboardData(text: md));
+                    if (!context.mounted) return;
+                    messenger.showSnackBar(
+                      const SnackBar(
+                        content: Text('Markdown in Zwischenablage'),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/week/widgets/week_navigation_bar.dart
+++ b/lib/features/week/widgets/week_navigation_bar.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+/// Navigations-Header für die Wochenansicht.
+///
+/// Zeigt Pfeile (links/rechts), Wochennummer + Datumsbereich, Heute-Button und Kalender-Picker.
+class WeekNavigationBar extends StatelessWidget {
+  final String weekId;
+  final String formattedRange;
+  final VoidCallback onPrevious;
+  final VoidCallback onNext;
+  final VoidCallback onToday;
+  final VoidCallback onPickDate;
+
+  const WeekNavigationBar({
+    super.key,
+    required this.weekId,
+    required this.formattedRange,
+    required this.onPrevious,
+    required this.onNext,
+    required this.onToday,
+    required this.onPickDate,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            IconButton(
+              tooltip: 'Vorherige Woche',
+              onPressed: onPrevious,
+              icon: const Icon(Icons.chevron_left_rounded),
+            ),
+            Expanded(
+              child: Text(
+                'Woche $weekId · $formattedRange',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+            IconButton(
+              tooltip: 'Nächste Woche',
+              onPressed: onNext,
+              icon: const Icon(Icons.chevron_right_rounded),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              formattedRange,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Theme.of(context).colorScheme.secondary,
+              ),
+            ),
+            const SizedBox(width: 12),
+            TextButton(onPressed: onToday, child: const Text('Heute')),
+            IconButton(
+              tooltip: 'Woche wählen',
+              icon: const Icon(Icons.calendar_month_outlined),
+              onPressed: onPickDate,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/week/widgets/week_stats_card.dart
+++ b/lib/features/week/widgets/week_stats_card.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../widgets/reflecto_card.dart';
+import '../../../widgets/reflecto_sparkline.dart';
+import '../logic/week_stats.dart';
+
+/// Übersichts-Card: zeigt Fokus/Energie/Zufriedenheit-Statistiken + Stimmungsverlauf.
+class WeekStatsCard extends StatelessWidget {
+  final WeekStats stats;
+
+  const WeekStatsCard({super.key, required this.stats});
+
+  @override
+  Widget build(BuildContext context) {
+    final nf = NumberFormat.decimalPattern();
+    nf.minimumFractionDigits = 2;
+    nf.maximumFractionDigits = 2;
+
+    return ReflectoCard(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Übersicht', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Text(
+            'Fokus: Ø ${nf.format(stats.focusAvg)} (min ${stats.focusMin ?? '-'}, max ${stats.focusMax ?? '-'})',
+          ),
+          Text(
+            'Energie: Ø ${nf.format(stats.energyAvg)} (min ${stats.energyMin ?? '-'}, max ${stats.energyMax ?? '-'})',
+          ),
+          Text(
+            'Zufriedenheit: Ø ${nf.format(stats.happinessAvg)} (min ${stats.happinessMin ?? '-'}, max ${stats.happinessMax ?? '-'})',
+          ),
+          const SizedBox(height: 8),
+          const Text('Stimmungsverlauf (1–5):'),
+          const SizedBox(height: 6),
+          ReflectoSparkline(points: stats.moodCurve),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,103 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:package_info_plus/package_info_plus.dart';
-import 'package:intl/intl.dart';
 
-import '../widgets/reflecto_button.dart';
 import '../theme/tokens.dart';
-import '../services/firestore_service.dart';
-import '../models/user_model.dart';
-import '../providers/settings_providers.dart';
-import '../utils/build_info.dart';
+import '../features/settings/widgets/theme_section.dart';
+import '../features/settings/widgets/maintenance_tools.dart';
+import '../features/settings/widgets/profile_section.dart';
+import '../features/settings/widgets/version_info.dart';
 
-class SettingsScreen extends ConsumerStatefulWidget {
+/// Einstellungen-Screen: Profil, Theme, Wartung
+class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
   @override
-  ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
-}
-
-class _SettingsScreenState extends ConsumerState<SettingsScreen> {
-  bool _loading = false;
-  final _nameCtrl = TextEditingController();
-  String? _email;
-  String? _version;
-  String? _buildInfo;
-
-  @override
-  void initState() {
-    super.initState();
-    final user = FirebaseAuth.instance.currentUser;
-    _email = user?.email;
-    _nameCtrl.text = user?.displayName ?? '';
-    _loadVersion();
-  }
-
-  @override
-  void dispose() {
-    _nameCtrl.dispose();
-    super.dispose();
-  }
-
-  Future<void> _loadVersion() async {
-    final info = await PackageInfo.fromPlatform();
-    if (!mounted) return;
-    // Show semantic version (from pubspec) and keep build/meta in separate row.
-    final version = info.version;
-    String displayTime = kBuildTime;
-    if (displayTime.isEmpty) {
-      displayTime = DateFormat('yyyy-MM-dd HH:mm').format(DateTime.now());
-    }
-    // Compose build string: buildNumber + channel + shortSha + time (where available)
-    final buildParts = <String>[
-      if (info.buildNumber.isNotEmpty && info.buildNumber != '0')
-        info.buildNumber,
-      if ((kBuildChannel).isNotEmpty) kBuildChannel else 'local',
-      if (shortGitSha().isNotEmpty) shortGitSha(),
-      displayTime,
-    ];
-    final build = buildParts.where((e) => e.isNotEmpty).join(' ');
-    setState(() {
-      _version = version;
-      _buildInfo = build;
-    });
-  }
-
-  Future<void> _saveProfile() async {
-    final user = FirebaseAuth.instance.currentUser;
-    if (user == null) return;
-    final newName = _nameCtrl.text.trim();
-    if (newName.isEmpty) return;
-    setState(() => _loading = true);
-    try {
-      await user.updateDisplayName(newName);
-      await FirestoreService().saveUserData(
-        AppUser(
-          uid: user.uid,
-          displayName: newName,
-          email: user.email,
-          photoUrl: user.photoURL,
-        ),
-      );
-      if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('Profil gespeichert')));
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Fehler beim Speichern: $e')));
-      }
-    } finally {
-      if (mounted) setState(() => _loading = false);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     const maxWidth = ReflectoBreakpoints.contentMax;
     return Center(
       child: ConstrainedBox(
@@ -113,15 +28,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 style: TextStyle(fontSize: 22, fontWeight: FontWeight.w600),
               ),
               const SizedBox(height: 8),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [const Text('Version'), Text(_version ?? '\u2026')],
-              ),
-              const SizedBox(height: 8),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [const Text('Build'), Text(_buildInfo ?? '')],
-              ),
+              const VersionInfo(),
               const SizedBox(height: 24),
 
               // Theme
@@ -130,7 +37,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 style: TextStyle(fontWeight: FontWeight.w600),
               ),
               const SizedBox(height: 8),
-              const _ThemeSection(),
+              const ThemeSection(),
               const SizedBox(height: 24),
 
               // Profile
@@ -139,30 +46,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 style: TextStyle(fontWeight: FontWeight.w600),
               ),
               const SizedBox(height: 8),
-              TextField(
-                controller: _nameCtrl,
-                decoration: const InputDecoration(
-                  labelText: 'Anzeigename',
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.all(Radius.circular(12)),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 8),
-              if (_email != null && _email!.isNotEmpty)
-                Text(
-                  'E-Mail: $_email',
-                  style: const TextStyle(color: Colors.grey),
-                ),
-              const SizedBox(height: 8),
-              Align(
-                alignment: Alignment.centerLeft,
-                child: ReflectoButton(
-                  text: _loading ? 'Speichern\u2026' : 'Profil speichern',
-                  icon: Icons.save_outlined,
-                  onPressed: _loading ? null : _saveProfile,
-                ),
-              ),
+              const ProfileSection(),
 
               const SizedBox(height: 24),
               const Divider(),
@@ -174,90 +58,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 style: TextStyle(fontWeight: FontWeight.w600),
               ),
               const SizedBox(height: 8),
-              _MaintenanceTools(),
+              const MaintenanceTools(),
             ],
           ),
         ),
-      ),
-    );
-  }
-}
-
-class _ThemeSection extends ConsumerWidget {
-  const _ThemeSection();
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final mode = ref.watch(themeModeProvider);
-    void setMode(AppThemeMode m) => ref.read(themeModeProvider.notifier).set(m);
-    return SegmentedButton<AppThemeMode>(
-      segments: const [
-        ButtonSegment(
-          value: AppThemeMode.system,
-          label: Text('System'),
-          icon: Icon(Icons.settings_suggest_outlined),
-        ),
-        ButtonSegment(
-          value: AppThemeMode.light,
-          label: Text('Hell'),
-          icon: Icon(Icons.light_mode_outlined),
-        ),
-        ButtonSegment(
-          value: AppThemeMode.dark,
-          label: Text('Dunkel'),
-          icon: Icon(Icons.dark_mode_outlined),
-        ),
-      ],
-      selected: {mode},
-      onSelectionChanged: (set) {
-        final sel = set.first;
-        setMode(sel);
-      },
-    );
-  }
-}
-
-class _MaintenanceTools extends ConsumerStatefulWidget {
-  @override
-  ConsumerState<_MaintenanceTools> createState() => _MaintenanceToolsState();
-}
-
-class _MaintenanceToolsState extends ConsumerState<_MaintenanceTools> {
-  bool _running = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final user = FirebaseAuth.instance.currentUser;
-    final uid = user?.uid;
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: ReflectoButton(
-        text: _running ? 'Bereinige...' : 'Planung deduplizieren',
-        icon: Icons.cleaning_services_outlined,
-        onPressed: (uid == null || _running)
-            ? null
-            : () async {
-                setState(() => _running = true);
-                try {
-                  final n = await FirestoreService().dedupeAllPlanningForUser(
-                    uid,
-                  );
-                  if (!context.mounted) return;
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(
-                        'Bereinigung abgeschlossen: $n Dokument(e) aktualisiert',
-                      ),
-                    ),
-                  );
-                } catch (e) {
-                  if (!context.mounted) return;
-                  ScaffoldMessenger.of(
-                    context,
-                  ).showSnackBar(SnackBar(content: Text('Fehler: $e')));
-                } finally {
-                  if (mounted) setState(() => _running = false);
-                }
-              },
       ),
     );
   }

--- a/lib/screens/week_screen.dart
+++ b/lib/screens/week_screen.dart
@@ -1,18 +1,17 @@
-import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter/services.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
-import '../models/journal_entry.dart';
 import '../services/firestore_service.dart';
-import '../widgets/reflecto_card.dart';
-import '../widgets/reflecto_button.dart';
-import '../widgets/reflecto_sparkline.dart';
-import 'package:intl/intl.dart';
 import '../services/export_import_service.dart';
 import '../providers/entry_providers.dart';
+import '../features/week/logic/week_stats.dart';
+import '../features/week/widgets/week_navigation_bar.dart';
+import '../features/week/widgets/week_stats_card.dart';
+import '../features/week/widgets/week_export_card.dart';
+import '../features/week/widgets/week_ai_analysis_card.dart';
 
+/// Wochenübersicht: Statistiken, Export, KI-Auswertung
 class WeekScreen extends ConsumerStatefulWidget {
   const WeekScreen({super.key});
 
@@ -21,9 +20,7 @@ class WeekScreen extends ConsumerStatefulWidget {
 }
 
 class _WeekScreenState extends ConsumerState<WeekScreen> {
-  final _svc = FirestoreService();
-  late DateTime _anchor; // any day in week
-  final TextEditingController _aiCtrl = TextEditingController();
+  late DateTime _anchor; // beliebiger Tag in der Woche
 
   @override
   void initState() {
@@ -31,74 +28,9 @@ class _WeekScreenState extends ConsumerState<WeekScreen> {
     _anchor = DateTime.now();
   }
 
-  @override
-  void dispose() {
-    _aiCtrl.dispose();
-    super.dispose();
-  }
-
-  // no-op
-
   String _formatDate(DateTime d) =>
       '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}.'
       '${d.year.toString()}';
-
-  Map<String, dynamic> _aggregate(
-    List<JournalEntry> entries,
-    DateTimeRange range,
-  ) {
-    int? minF, minE, minH, maxF, maxE, maxH;
-    double sumF = 0, sumE = 0, sumH = 0;
-    int cF = 0, cE = 0, cH = 0;
-    // mood curve for 7 days
-    final mood = List<int?>.filled(7, null);
-    final byId = {for (final e in entries) e.id: e};
-    for (var i = 0; i < 7; i++) {
-      final day = range.start.add(Duration(days: i));
-      final id =
-          '${day.year}-${day.month.toString().padLeft(2, '0')}-${day.day.toString().padLeft(2, '0')}';
-      final e = byId[id];
-      if (e != null) {
-        final f = e.ratingFocus;
-        final en = e.ratingEnergy;
-        final h = e.ratingHappiness;
-        if (f != null) {
-          sumF += f;
-          cF++;
-          minF = (minF == null) ? f : (f < minF ? f : minF);
-          maxF = (maxF == null) ? f : (f > maxF ? f : maxF);
-        }
-        if (en != null) {
-          sumE += en;
-          cE++;
-          minE = (minE == null) ? en : (en < minE ? en : minE);
-          maxE = (maxE == null) ? en : (en > maxE ? en : maxE);
-        }
-        if (h != null) {
-          sumH += h;
-          cH++;
-          minH = (minH == null) ? h : (h < minH ? h : minH);
-          maxH = (maxH == null) ? h : (h > maxH ? h : maxH);
-          mood[i] = h;
-        }
-      }
-    }
-    double avg(double s, int c) => c == 0 ? 0 : (s / c);
-    return {
-      'focusAvg': avg(sumF, cF),
-      'energyAvg': avg(sumE, cE),
-      'happinessAvg': avg(sumH, cH),
-      'focusMin': minF,
-      'energyMin': minE,
-      'happinessMin': minH,
-      'focusMax': maxF,
-      'energyMax': maxE,
-      'happinessMax': maxH,
-      'moodCurve': mood.map((e) => e ?? 0).toList(),
-    };
-  }
-
-  final _exportSvc = ExportImportService();
 
   @override
   Widget build(BuildContext context) {
@@ -106,11 +38,13 @@ class _WeekScreenState extends ConsumerState<WeekScreen> {
     if (user == null) {
       return const Scaffold(body: Center(child: Text('Bitte einloggen.')));
     }
+
     final uid = user.uid;
     final range = FirestoreService.weekRangeFrom(_anchor);
     final weekId = FirestoreService.weekIdFrom(_anchor);
     final entriesAsync = ref.watch(weekEntriesProvider(_anchor));
     final weeklyAsync = ref.watch(weeklyReflectionProvider(weekId));
+    final exportSvc = ExportImportService();
 
     return Scaffold(
       body: SafeArea(
@@ -122,313 +56,67 @@ class _WeekScreenState extends ConsumerState<WeekScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  Row(
-                    children: [
-                      IconButton(
-                        tooltip: 'Vorherige Woche',
-                        onPressed: () {
-                          setState(() {
-                            _anchor = _anchor.subtract(const Duration(days: 7));
-                          });
-                        },
-                        icon: const Icon(Icons.chevron_left_rounded),
-                      ),
-                      Expanded(
-                        child: Text(
-                          'Woche ${FirestoreService.weekIdFrom(_anchor)} · ${_formatDate(range.start)} – ${_formatDate(range.end)}',
-                          textAlign: TextAlign.center,
-                          style: Theme.of(context).textTheme.titleMedium,
-                        ),
-                      ),
-                      IconButton(
-                        tooltip: 'Nächste Woche',
-                        onPressed: () {
-                          setState(() {
-                            _anchor = _anchor.add(const Duration(days: 7));
-                          });
-                        },
-                        icon: const Icon(Icons.chevron_right_rounded),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 12),
-                  // Zusatz: Datumszeile + Woche wählen + Heute-Button
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        '${_formatDate(range.start)} – ${_formatDate(range.end)}',
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: Theme.of(context).colorScheme.secondary,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      TextButton(
-                        onPressed: () {
-                          setState(() {
-                            _anchor = DateTime.now();
-                          });
-                        },
-                        child: const Text('Heute'),
-                      ),
-                      IconButton(
-                        tooltip: 'Woche wählen',
-                        icon: const Icon(Icons.calendar_month_outlined),
-                        onPressed: () async {
-                          final picked = await showDatePicker(
-                            context: context,
-                            initialDate: _anchor,
-                            firstDate: DateTime(2000),
-                            lastDate: DateTime(2100),
-                          );
-                          if (picked != null) {
-                            if (!mounted) return;
-                            setState(() {
-                              _anchor = picked;
-                            });
-                          }
-                        },
-                      ),
-                    ],
+                  WeekNavigationBar(
+                    weekId: weekId,
+                    formattedRange:
+                        '${_formatDate(range.start)}  ${_formatDate(range.end)}',
+                    onPrevious: () {
+                      setState(() {
+                        _anchor = _anchor.subtract(const Duration(days: 7));
+                      });
+                    },
+                    onNext: () {
+                      setState(() {
+                        _anchor = _anchor.add(const Duration(days: 7));
+                      });
+                    },
+                    onToday: () {
+                      setState(() {
+                        _anchor = DateTime.now();
+                      });
+                    },
+                    onPickDate: () async {
+                      final picked = await showDatePicker(
+                        context: context,
+                        initialDate: _anchor,
+                        firstDate: DateTime(2000),
+                        lastDate: DateTime(2100),
+                      );
+                      if (picked != null) {
+                        if (!mounted) return;
+                        setState(() {
+                          _anchor = picked;
+                        });
+                      }
+                    },
                   ),
                   const SizedBox(height: 8),
-
                   Expanded(
                     child: entriesAsync.when(
                       loading: () =>
                           const Center(child: CircularProgressIndicator()),
                       error: (e, st) => Center(child: Text('Fehler: $e')),
                       data: (entries) {
-                        final aggr = _aggregate(entries, range);
-                        final jsonData = _exportSvc.buildWeekExportJson(
+                        final stats = WeekStats.aggregate(entries, range);
+                        final jsonData = exportSvc.buildWeekExportJson(
                           weekId,
                           range,
                           entries,
-                          aggr,
+                          stats.toJson(),
                         );
 
-                        final nf = NumberFormat.decimalPattern();
-                        nf.minimumFractionDigits = 2;
-                        nf.maximumFractionDigits = 2;
                         return ListView(
                           children: [
-                            ReflectoCard(
-                              margin: const EdgeInsets.only(bottom: 12),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    'Übersicht',
-                                    style: Theme.of(
-                                      context,
-                                    ).textTheme.titleMedium,
-                                  ),
-                                  const SizedBox(height: 8),
-                                  Text(
-                                    'Fokus: Ø ${nf.format(aggr['focusAvg'])} (min ${aggr['focusMin'] ?? '-'}, max ${aggr['focusMax'] ?? '-'})',
-                                  ),
-                                  Text(
-                                    'Energie: Ø ${nf.format(aggr['energyAvg'])} (min ${aggr['energyMin'] ?? '-'}, max ${aggr['energyMax'] ?? '-'})',
-                                  ),
-                                  Text(
-                                    'Zufriedenheit: Ø ${nf.format(aggr['happinessAvg'])} (min ${aggr['happinessMin'] ?? '-'}, max ${aggr['happinessMax'] ?? '-'})',
-                                  ),
-                                  const SizedBox(height: 8),
-                                  const Text('Stimmungsverlauf (1–5):'),
-                                  const SizedBox(height: 6),
-                                  ReflectoSparkline(
-                                    points: List<int>.from(
-                                      aggr['moodCurve'] as List,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-
-                            ReflectoCard(
-                              margin: const EdgeInsets.only(bottom: 12),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    'Export',
-                                    style: Theme.of(
-                                      context,
-                                    ).textTheme.titleMedium,
-                                  ),
-                                  const SizedBox(height: 8),
-                                  Row(
-                                    children: [
-                                      Expanded(
-                                        child: ReflectoButton(
-                                          text: 'JSON kopieren',
-                                          onPressed: () async {
-                                            final messenger =
-                                                ScaffoldMessenger.of(context);
-                                            await Clipboard.setData(
-                                              ClipboardData(
-                                                text: jsonEncode(jsonData),
-                                              ),
-                                            );
-                                            if (!mounted) return;
-                                            messenger.showSnackBar(
-                                              const SnackBar(
-                                                content: Text(
-                                                  'JSON in Zwischenablage',
-                                                ),
-                                              ),
-                                            );
-                                          },
-                                        ),
-                                      ),
-                                      const SizedBox(width: 12),
-                                      Expanded(
-                                        child: ReflectoButton(
-                                          text: 'Markdown kopieren',
-                                          onPressed: () async {
-                                            final messenger =
-                                                ScaffoldMessenger.of(context);
-                                            final md = _exportSvc
-                                                .buildMarkdownFromJson(
-                                                  jsonData,
-                                                );
-                                            await Clipboard.setData(
-                                              ClipboardData(text: md),
-                                            );
-                                            if (!mounted) return;
-                                            messenger.showSnackBar(
-                                              const SnackBar(
-                                                content: Text(
-                                                  'Markdown in Zwischenablage',
-                                                ),
-                                              ),
-                                            );
-                                          },
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ],
-                              ),
-                            ),
-
+                            WeekStatsCard(stats: stats),
+                            WeekExportCard(jsonData: jsonData),
                             weeklyAsync.when(
-                              loading: () => const ReflectoCard(
-                                child: Padding(
-                                  padding: EdgeInsets.all(16),
-                                  child: Center(
-                                    child: CircularProgressIndicator(),
-                                  ),
-                                ),
-                              ),
-                              error: (e, st) => ReflectoCard(
-                                child: Padding(
-                                  padding: const EdgeInsets.all(16),
-                                  child: Text('Fehler: $e'),
-                                ),
-                              ),
-                              data: (data) {
-                                final motto = data?['motto'] as String?;
-                                final summary = data?['summaryText'] as String?;
-                                final ai = data?['aiAnalysis'];
-                                return ReflectoCard(
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        'KI-Auswertung / Notizen',
-                                        style: Theme.of(
-                                          context,
-                                        ).textTheme.titleMedium,
-                                      ),
-                                      if (motto != null &&
-                                          motto.isNotEmpty) ...[
-                                        const SizedBox(height: 8),
-                                        Text(
-                                          'Motto: $motto',
-                                          style: const TextStyle(
-                                            fontWeight: FontWeight.w600,
-                                          ),
-                                        ),
-                                      ],
-                                      if (summary != null &&
-                                          summary.isNotEmpty) ...[
-                                        const SizedBox(height: 8),
-                                        Text(summary),
-                                      ],
-                                      if (ai != null) ...[
-                                        const SizedBox(height: 8),
-                                        Text(
-                                          'AI-Daten vorhanden',
-                                          style: TextStyle(
-                                            color: Theme.of(
-                                              context,
-                                            ).colorScheme.secondary,
-                                          ),
-                                        ),
-                                      ],
-                                      const SizedBox(height: 12),
-                                      TextField(
-                                        controller: _aiCtrl,
-                                        maxLines: null,
-                                        decoration: const InputDecoration(
-                                          hintText:
-                                              'KI-Auswertung hier einfügen (Text oder JSON)…',
-                                          border: OutlineInputBorder(
-                                            borderRadius: BorderRadius.all(
-                                              Radius.circular(12),
-                                            ),
-                                          ),
-                                        ),
-                                      ),
-                                      const SizedBox(height: 8),
-                                      Row(
-                                        children: [
-                                          Expanded(
-                                            child: ReflectoButton(
-                                              text: 'Importieren & Speichern',
-                                              onPressed: () async {
-                                                final messenger =
-                                                    ScaffoldMessenger.of(
-                                                      context,
-                                                    );
-                                                final input = _aiCtrl.text
-                                                    .trim();
-                                                if (input.isEmpty) return;
-                                                final parsed = _exportSvc
-                                                    .tryParseAiAnalysis(input);
-                                                final toSave =
-                                                    parsed != null &&
-                                                        parsed.containsKey(
-                                                          'text',
-                                                        )
-                                                    ? {
-                                                        'aiAnalysisText':
-                                                            parsed['text'],
-                                                      }
-                                                    : {'aiAnalysis': parsed};
-                                                await _svc.saveWeeklyReflection(
-                                                  uid,
-                                                  weekId,
-                                                  toSave,
-                                                );
-                                                if (!mounted) return;
-                                                messenger.showSnackBar(
-                                                  const SnackBar(
-                                                    content: Text(
-                                                      'Auswertung gespeichert',
-                                                    ),
-                                                  ),
-                                                );
-                                                _aiCtrl.clear();
-                                              },
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ],
-                                  ),
+                              loading: () => const SizedBox(),
+                              error: (e, st) => Text('Fehler: $e'),
+                              data: (weeklyData) {
+                                return WeekAiAnalysisCard(
+                                  uid: uid,
+                                  weekId: weekId,
+                                  weeklyData: weeklyData,
                                 );
                               },
                             ),


### PR DESCRIPTION
## Änderungen

### Settings-Screen (~265  ~71 Zeilen, -73%)
- **ThemeSection**: System/Hell/Dunkel-Auswahl
- **MaintenanceTools**: Planung deduplizieren
- **ProfileSection**: Anzeigename bearbeiten & speichern
- **VersionInfo**: App-Version & Build-Info
- Alle Widgets nach \lib/features/settings/widgets/\

### Week-Screen (~432  ~147 Zeilen, -66%)
- **WeekStats** (Logik): Aggregation von Fokus/Energie/Zufriedenheit in \lib/features/week/logic/week_stats.dart\
- **WeekNavigationBar**: Pfeile, Datumswahl, Heute-Button
- **WeekStatsCard**: Übersicht + Stimmungsverlauf (Sparkline)
- **WeekExportCard**: JSON/Markdown-Export
- **WeekAiAnalysisCard**: KI-Auswertung importieren & speichern
- Alle Widgets nach \lib/features/week/widgets/\

## Validierung
-  \lutter analyze\: Keine Befunde
-  Verhalten unverändert (reine Extraktion, keine Business-Logik-Änderungen)
-  Struktur folgt Coding Guidelines (Widget-Aufteilung, Feature-Ordner)

Closes #71