### PR TITLE
refactor(providers): Riverpod Performance-Optimierung (#51)

### DIFF
--- a/lib/providers/entry_providers.dart
+++ b/lib/providers/entry_providers.dart
@@ -15,14 +15,13 @@ final todayEntryProvider = StreamProvider<JournalEntry?>((ref) {
   return svc.getDailyEntry(user.uid, today);
 });
 
-final weekEntriesProvider = FutureProvider.family<List<JournalEntry>, DateTime>(
-  (ref, anyDayInWeek) async {
-    final user = FirebaseAuth.instance.currentUser;
-    if (user == null) return <JournalEntry>[];
-    final svc = ref.read(_svcProvider);
-    return svc.fetchWeekEntries(user.uid, anyDayInWeek);
-  },
-);
+final weekEntriesProvider = FutureProvider.autoDispose
+    .family<List<JournalEntry>, DateTime>((ref, anyDayInWeek) async {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) return <JournalEntry>[];
+      final svc = ref.read(_svcProvider);
+      return svc.fetchWeekEntries(user.uid, anyDayInWeek);
+    });
 
 // Document stream for today to access snapshot metadata (pending/offline)
 final todayDocProvider = StreamProvider<DocumentSnapshot<Map<String, dynamic>>>(
@@ -38,8 +37,8 @@ final todayDocProvider = StreamProvider<DocumentSnapshot<Map<String, dynamic>>>(
 );
 
 // Weekly reflection stream provider
-final weeklyReflectionProvider =
-    StreamProvider.family<Map<String, dynamic>?, String>((ref, weekId) {
+final weeklyReflectionProvider = StreamProvider.autoDispose
+    .family<Map<String, dynamic>?, String>((ref, weekId) {
       final user = FirebaseAuth.instance.currentUser;
       if (user == null) return const Stream.empty();
       final refDoc = FirebaseFirestore.instance.doc(
@@ -49,21 +48,16 @@ final weeklyReflectionProvider =
     });
 
 // Family providers by date for day views
-final dayEntryProvider = StreamProvider.family<JournalEntry?, DateTime>((
-  ref,
-  date,
-) {
-  final user = FirebaseAuth.instance.currentUser;
-  if (user == null) return const Stream.empty();
-  final svc = ref.read(_svcProvider);
-  return svc.getDailyEntry(user.uid, date);
-});
+final dayEntryProvider = StreamProvider.autoDispose
+    .family<JournalEntry?, DateTime>((ref, date) {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) return const Stream.empty();
+      final svc = ref.read(_svcProvider);
+      return svc.getDailyEntry(user.uid, date);
+    });
 
-final dayDocProvider =
-    StreamProvider.family<DocumentSnapshot<Map<String, dynamic>>, DateTime>((
-      ref,
-      date,
-    ) {
+final dayDocProvider = StreamProvider.autoDispose
+    .family<DocumentSnapshot<Map<String, dynamic>>, DateTime>((ref, date) {
       final user = FirebaseAuth.instance.currentUser;
       if (user == null) return const Stream.empty();
       String two(int n) => n.toString().padLeft(2, '0');


### PR DESCRIPTION
## Änderungen

### autoDispose für temporäre .family Provider
Alle datums-/kontextspezifischen Provider nutzen jetzt \utoDispose\:
- \weekEntriesProvider\: FutureProvider.autoDispose.family
- \weeklyReflectionProvider\: StreamProvider.autoDispose.family
- \dayEntryProvider\: StreamProvider.autoDispose.family
- \dayDocProvider\: StreamProvider.autoDispose.family

### Vorteile
-  **Automatische Bereinigung**: Provider-Instanzen werden entfernt, sobald sie nicht mehr genutzt werden
-  **Reduzierter Speicherverbrauch**: Keine Caches für alte Datums-Queries
-  **Keine Memory Leaks**: Stream-Subscriptions werden automatisch geschlossen

### Weitere Optimierungen geprüft
- \ef.watch\/\ef.read\: Korrekt eingesetzt (watch für reaktive Updates, read für einmalige Zugriffe)
- Provider-Kaskaden: Keine unnötigen Abhängigkeiten erkannt
- Doppelabfragen: Keine Redundanzen gefunden

## Validierung
-  \lutter analyze\: Keine Befunde
-  Verhalten unverändert (reine Performance-Optimierung)

Refs #51