### PR TITLE
Firestore Typisierung + UI Tokens (Issues #52, #53)

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -28,6 +28,7 @@ Kurzer Überblick über die Design‑Tokens und Leitlinien. Ziel: konsistente, l
 - Titel: Lexend (fett), Hierarchien über Theme (`titleLarge`/`titleMedium`)
 - Fließtext: Inter (16/15/13), erhöhte Zeilenhöhe
 - Einheitliche Textfarben je Mode aus dem Theme
+ - Keine Inline-`TextStyle` für Größe/Gewicht, wenn eine passende Style im Theme existiert.
 
 ## Farben
 
@@ -55,6 +56,6 @@ Kurzer Überblick über die Design‑Tokens und Leitlinien. Ziel: konsistente, l
 ## Layout & Responsiveness
 
 - Contentbreite max. 820 px (Center + ConstrainedBox)
-- Spacing‑Stufen 4/8/12/16/24
-- Keine harten Hex‑Farben/Abstände in Widgets — statt dessen Tokens/Theme verwenden
+- Spacing‑Stufen 4/8/12/16/24 über `ReflectoSpacing` Tokens nutzen (`s4/s8/s12/s16/s24`).
+- Keine harten Hex‑Farben/Abstände in Widgets — statt dessen Tokens/Theme verwenden.
 

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -28,9 +28,23 @@
   - happiness: int? (1–5)
 - migratedV1: bool (true, wenn Slots normalisiert)
 - updatedAt: Timestamp
+- createdAt: Timestamp (gesetzt bei erstmaligem Anlegen)
+ - updatedAt: Timestamp
 
 ## Hinweise
 - App normalisiert verdichtete Arrays auf 3 Slots und setzt `migratedV1=true`.
 - Leere Ziele/To-dos werden im UI ausgeblendet; Speicherung behält Slots für Positionsstabilität.
-- Morgen‑Ratings und Abend‑Ratings getrennt (`ratingsMorning` vs. `ratingsEvening`).
+ - Morgen‑Ratings und Abend‑Ratings getrennt (`ratingsMorning` vs. `ratingsEvening`).
+ - Neu: `createdAt` wird beim erstmaligen Anlegen eines Eintrags gesetzt; bestehende Dokumente behalten nur `updatedAt`.
+
+## weekly_reflections/{yyyy-ww}
+
+- motto: String?
+- summaryText: String?
+- aiAnalysisText: String? (plain Text extrahiert)
+- aiAnalysis: Map<String, any>? (strukturierte Analyse-Daten)
+- updatedAt: Timestamp
+
+Hinweise:
+- Lesezugriff ist typisiert über `WeeklyReflection`; Schreibzugriff erfolgt entweder per Map-Merge (`saveWeeklyReflection`) oder typisiert (`saveWeeklyReflectionModel`).
 

--- a/lib/features/settings/widgets/profile_section.dart
+++ b/lib/features/settings/widgets/profile_section.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../../../services/firestore_service.dart';
 import '../../../models/user_model.dart';
 import '../../../widgets/reflecto_button.dart';
+import '../../../theme/tokens.dart';
 
 /// Profil-Bereich: Anzeigename bearbeiten und speichern
 class ProfileSection extends StatefulWidget {
@@ -79,10 +80,10 @@ class _ProfileSectionState extends State<ProfileSection> {
             ),
           ),
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: ReflectoSpacing.s8),
         if (_email != null && _email!.isNotEmpty)
-          Text('E-Mail: $_email', style: const TextStyle(color: Colors.grey)),
-        const SizedBox(height: 8),
+          Text('E-Mail: $_email', style: Theme.of(context).textTheme.bodySmall),
+        const SizedBox(height: ReflectoSpacing.s8),
         Align(
           alignment: Alignment.centerLeft,
           child: ReflectoButton(

--- a/lib/features/settings/widgets/version_info.dart
+++ b/lib/features/settings/widgets/version_info.dart
@@ -3,6 +3,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:intl/intl.dart';
 
 import '../../../utils/build_info.dart';
+import '../../../theme/tokens.dart';
 
 /// Versions- und Build-Informationen
 class VersionInfo extends StatefulWidget {
@@ -55,12 +56,24 @@ class _VersionInfoState extends State<VersionInfo> {
       children: [
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [const Text('Version'), Text(_version ?? '…')],
+          children: [
+            Text('Version', style: Theme.of(context).textTheme.bodySmall),
+            Text(
+              _version ?? '…',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: ReflectoSpacing.s8),
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [const Text('Build'), Text(_buildInfo ?? '')],
+          children: [
+            Text('Build', style: Theme.of(context).textTheme.bodySmall),
+            Text(
+              _buildInfo ?? '',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
         ),
       ],
     );

--- a/lib/features/week/widgets/week_ai_analysis_card.dart
+++ b/lib/features/week/widgets/week_ai_analysis_card.dart
@@ -3,13 +3,15 @@ import 'package:flutter/material.dart';
 import '../../../widgets/reflecto_card.dart';
 import '../../../widgets/reflecto_button.dart';
 import '../../../services/firestore_service.dart';
+import '../../../models/weekly_reflection.dart';
 import '../../../services/export_import_service.dart';
+import '../../../theme/tokens.dart';
 
 /// KI-Auswertung/Notizen-Card: Textfeld für Import + Speichern-Button.
 class WeekAiAnalysisCard extends StatefulWidget {
   final String uid;
   final String weekId;
-  final Map<String, dynamic>? weeklyData;
+  final WeeklyReflection? weeklyData;
 
   const WeekAiAnalysisCard({
     super.key,
@@ -35,9 +37,9 @@ class _WeekAiAnalysisCardState extends State<WeekAiAnalysisCard> {
 
   @override
   Widget build(BuildContext context) {
-    final motto = widget.weeklyData?['motto'] as String?;
-    final summary = widget.weeklyData?['summaryText'] as String?;
-    final ai = widget.weeklyData?['aiAnalysis'];
+    final motto = widget.weeklyData?.motto;
+    final summary = widget.weeklyData?.summaryText;
+    final ai = widget.weeklyData?.aiAnalysis;
 
     return ReflectoCard(
       child: Column(
@@ -48,24 +50,24 @@ class _WeekAiAnalysisCardState extends State<WeekAiAnalysisCard> {
             style: Theme.of(context).textTheme.titleMedium,
           ),
           if (motto != null && motto.isNotEmpty) ...[
-            const SizedBox(height: 8),
+            const SizedBox(height: ReflectoSpacing.s8),
             Text(
               'Motto: $motto',
               style: const TextStyle(fontWeight: FontWeight.w600),
             ),
           ],
           if (summary != null && summary.isNotEmpty) ...[
-            const SizedBox(height: 8),
+            const SizedBox(height: ReflectoSpacing.s8),
             Text(summary),
           ],
           if (ai != null) ...[
-            const SizedBox(height: 8),
+            const SizedBox(height: ReflectoSpacing.s8),
             Text(
               'AI-Daten vorhanden',
               style: TextStyle(color: Theme.of(context).colorScheme.secondary),
             ),
           ],
-          const SizedBox(height: 12),
+          const SizedBox(height: ReflectoSpacing.s12),
           TextField(
             controller: _aiCtrl,
             maxLines: null,
@@ -76,7 +78,7 @@ class _WeekAiAnalysisCardState extends State<WeekAiAnalysisCard> {
               ),
             ),
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: ReflectoSpacing.s8),
           Row(
             children: [
               Expanded(

--- a/lib/models/weekly_reflection.dart
+++ b/lib/models/weekly_reflection.dart
@@ -1,0 +1,49 @@
+import 'package:cloud_firestore/cloud_firestore.dart' show Timestamp;
+
+class WeeklyReflection {
+  final String id; // yyyy-ww (ISO Woche)
+  final String? motto;
+  final String? summaryText;
+  final String? aiAnalysisText;
+  final Map<String, dynamic>? aiAnalysis;
+  final DateTime? updatedAt;
+
+  const WeeklyReflection({
+    required this.id,
+    this.motto,
+    this.summaryText,
+    this.aiAnalysisText,
+    this.aiAnalysis,
+    this.updatedAt,
+  });
+
+  Map<String, dynamic> toMap() => {
+    if (motto != null) 'motto': motto,
+    if (summaryText != null) 'summaryText': summaryText,
+    if (aiAnalysisText != null) 'aiAnalysisText': aiAnalysisText,
+    if (aiAnalysis != null) 'aiAnalysis': aiAnalysis,
+    'updatedAt': updatedAt,
+  };
+
+  factory WeeklyReflection.fromMap(String id, Map<String, dynamic> map) {
+    DateTime? updated;
+    final raw = map['updatedAt'];
+    if (raw is Timestamp) {
+      updated = raw.toDate();
+    } else if (raw is DateTime) {
+      updated = raw;
+    } else if (raw != null) {
+      updated = DateTime.tryParse(raw.toString());
+    }
+    return WeeklyReflection(
+      id: id,
+      motto: map['motto'] as String?,
+      summaryText: map['summaryText'] as String?,
+      aiAnalysisText: map['aiAnalysisText'] as String?,
+      aiAnalysis: map['aiAnalysis'] is Map<String, dynamic>
+          ? Map<String, dynamic>.from(map['aiAnalysis'] as Map)
+          : null,
+      updatedAt: updated,
+    );
+  }
+}

--- a/lib/providers/entry_providers.dart
+++ b/lib/providers/entry_providers.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../models/journal_entry.dart';
+import '../models/weekly_reflection.dart';
 import 'pending_providers.dart';
 import '../services/firestore_service.dart';
 
@@ -38,13 +39,11 @@ final todayDocProvider = StreamProvider<DocumentSnapshot<Map<String, dynamic>>>(
 
 // Weekly reflection stream provider
 final weeklyReflectionProvider = StreamProvider.autoDispose
-    .family<Map<String, dynamic>?, String>((ref, weekId) {
+    .family<WeeklyReflection?, String>((ref, weekId) {
       final user = FirebaseAuth.instance.currentUser;
       if (user == null) return const Stream.empty();
-      final refDoc = FirebaseFirestore.instance.doc(
-        'users/${user.uid}/weekly_reflections/$weekId',
-      );
-      return refDoc.snapshots().map((s) => s.data());
+      final svc = ref.read(_svcProvider);
+      return svc.weeklyReflectionStream(user.uid, weekId);
     });
 
 // Family providers by date for day views

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -18,46 +18,39 @@ class SettingsScreen extends ConsumerWidget {
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: maxWidth),
         child: Padding(
-          padding: const EdgeInsets.all(24),
+          padding: const EdgeInsets.all(ReflectoSpacing.s24),
           child: ListView(
             shrinkWrap: true,
             children: [
-              const Text(
+              Text(
                 'Einstellungen',
                 textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 22, fontWeight: FontWeight.w600),
+                style: Theme.of(context).textTheme.titleLarge,
               ),
-              const SizedBox(height: 8),
+              const SizedBox(height: ReflectoSpacing.s8),
               const VersionInfo(),
-              const SizedBox(height: 24),
+              const SizedBox(height: ReflectoSpacing.s24),
 
               // Theme
-              const Text(
+              Text(
                 'Darstellung',
-                style: TextStyle(fontWeight: FontWeight.w600),
+                style: Theme.of(context).textTheme.titleMedium,
               ),
-              const SizedBox(height: 8),
+              const SizedBox(height: ReflectoSpacing.s8),
               const ThemeSection(),
-              const SizedBox(height: 24),
+              const SizedBox(height: ReflectoSpacing.s24),
 
               // Profile
-              const Text(
-                'Profil',
-                style: TextStyle(fontWeight: FontWeight.w600),
-              ),
-              const SizedBox(height: 8),
+              Text('Profil', style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: ReflectoSpacing.s8),
               const ProfileSection(),
-
-              const SizedBox(height: 24),
+              const SizedBox(height: ReflectoSpacing.s24),
               const Divider(),
-              const SizedBox(height: 12),
+              const SizedBox(height: ReflectoSpacing.s12),
 
               // Wartung / Tools
-              const Text(
-                'Wartung',
-                style: TextStyle(fontWeight: FontWeight.w600),
-              ),
-              const SizedBox(height: 8),
+              Text('Wartung', style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: ReflectoSpacing.s8),
               const MaintenanceTools(),
             ],
           ),

--- a/lib/screens/week_screen.dart
+++ b/lib/screens/week_screen.dart
@@ -10,6 +10,7 @@ import '../features/week/widgets/week_navigation_bar.dart';
 import '../features/week/widgets/week_stats_card.dart';
 import '../features/week/widgets/week_export_card.dart';
 import '../features/week/widgets/week_ai_analysis_card.dart';
+import '../theme/tokens.dart';
 
 /// Wochenübersicht: Statistiken, Export, KI-Auswertung
 class WeekScreen extends ConsumerStatefulWidget {
@@ -52,7 +53,7 @@ class _WeekScreenState extends ConsumerState<WeekScreen> {
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 820),
             child: Padding(
-              padding: const EdgeInsets.all(16),
+              padding: const EdgeInsets.all(ReflectoSpacing.s16),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
@@ -90,7 +91,7 @@ class _WeekScreenState extends ConsumerState<WeekScreen> {
                       }
                     },
                   ),
-                  const SizedBox(height: 8),
+                  const SizedBox(height: ReflectoSpacing.s8),
                   Expanded(
                     child: entriesAsync.when(
                       loading: () =>

--- a/test/weekly_reflection_model_test.dart
+++ b/test/weekly_reflection_model_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:reflecto/models/weekly_reflection.dart';
+
+void main() {
+  group('WeeklyReflection model', () {
+    test('fromMap parses Timestamp and fields', () {
+      final ts = Timestamp.fromMillisecondsSinceEpoch(1700000000000);
+      final map = {
+        'motto': 'Focus & Flow',
+        'summaryText': 'Gute Woche mit konstantem Fokus.',
+        'aiAnalysisText': 'Zusammenfassung...',
+        'aiAnalysis': {
+          'score': 0.87,
+          'keywords': ['focus', 'energy'],
+        },
+        'updatedAt': ts,
+      };
+      final wr = WeeklyReflection.fromMap('2025-46', map);
+      expect(wr.id, '2025-46');
+      expect(wr.motto, 'Focus & Flow');
+      expect(wr.summaryText, 'Gute Woche mit konstantem Fokus.');
+      expect(wr.aiAnalysisText, 'Zusammenfassung...');
+      expect(wr.aiAnalysis, isA<Map<String, dynamic>>());
+      expect(wr.updatedAt, isA<DateTime>());
+    });
+
+    test('toMap serializes provided fields and updatedAt', () {
+      final now = DateTime.now();
+      final wr = WeeklyReflection(
+        id: '2025-46',
+        motto: 'Keep it simple',
+        summaryText: 'Stabile Routinen.',
+        aiAnalysisText: 'Kurztext',
+        aiAnalysis: {'score': 0.9},
+        updatedAt: now,
+      );
+      final m = wr.toMap();
+      expect(m['motto'], 'Keep it simple');
+      expect(m['summaryText'], 'Stabile Routinen.');
+      expect(m['aiAnalysisText'], 'Kurztext');
+      expect(m['aiAnalysis'], {'score': 0.9});
+      expect(m['updatedAt'], now);
+    });
+  });
+}


### PR DESCRIPTION
Dieser PR fasst zwei sinnvolle, kleine Pakete zusammen: Datenmodell/Performance (#52) und UI/Design-Konsistenz (#53).

Änderungen
- Firestore (#52)
  - Entries: typed Streams/Fetches via withConverter<JournalEntry>
  - Users: typed Doc via withConverter<AppUser>
  - WeeklyReflections: neues Model, typed Stream, typisierte Save-Methode
  - createdAt bei Erstanlage von Tages-Dokumenten; updatedAt via serverTimestamp
  - Streak-Update atomar in einer Transaction (Abend completed + Streak-Zähler)
  - Maintenance: Dedupe in Batches (schneller/ressourcenschonend)

- UI/Design (#53)
  - Spacing über ReflectoSpacing (s8/s12/s16/s24) statt Magic Numbers
  - Titel/Labels über Theme-TextStyles (titleLarge/titleMedium/body*) statt Inline-Styles
  - Aktualisiert: SettingsScreen, VersionInfo, ProfileSection, WeekScreen, WeekAiAnalysisCard
  - STYLEGUIDE präzisiert: Tokens & Theme bevorzugen

Validierung
- flutter analyze: OK
- flutter test: OK (inkl. neuem WeeklyReflection-Modelltest)

Migrations-/RisikoEinschätzung
- Rückwärtskompatibel: Felder bleiben gleich; nur Typisierung auf App-Seite und bessere Timestamps
- UI rein kosmetisch/konsequent; keine Logikänderung

Bitte Review. Wenn passend, kann direkt gemergt werden (Squash).