### PR TITLE
feat(meals): Add Time Picker for Meal Entries

### DIFF
--- a/lib/models/meal_log.dart
+++ b/lib/models/meal_log.dart
@@ -13,6 +13,11 @@ class MealLog {
   final String? lunchNote;
   final String? dinnerNote;
 
+  /// Zeitstempel für Mahlzeiten im Format "HH:mm"
+  final String? breakfastTime;
+  final String? lunchTime;
+  final String? dinnerTime;
+
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -24,6 +29,9 @@ class MealLog {
     this.breakfastNote,
     this.lunchNote,
     this.dinnerNote,
+    this.breakfastTime,
+    this.lunchTime,
+    this.dinnerTime,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -37,6 +45,9 @@ class MealLog {
       breakfastNote: map['breakfastNote'] as String?,
       lunchNote: map['lunchNote'] as String?,
       dinnerNote: map['dinnerNote'] as String?,
+      breakfastTime: map['breakfastTime'] as String?,
+      lunchTime: map['lunchTime'] as String?,
+      dinnerTime: map['dinnerTime'] as String?,
       createdAt: (map['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
       updatedAt: (map['updatedAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
     );
@@ -50,6 +61,9 @@ class MealLog {
       if (breakfastNote != null) 'breakfastNote': breakfastNote,
       if (lunchNote != null) 'lunchNote': lunchNote,
       if (dinnerNote != null) 'dinnerNote': dinnerNote,
+      if (breakfastTime != null) 'breakfastTime': breakfastTime,
+      if (lunchTime != null) 'lunchTime': lunchTime,
+      if (dinnerTime != null) 'dinnerTime': dinnerTime,
       'createdAt': Timestamp.fromDate(createdAt),
       'updatedAt': FieldValue.serverTimestamp(),
     };
@@ -63,6 +77,9 @@ class MealLog {
     String? breakfastNote,
     String? lunchNote,
     String? dinnerNote,
+    String? breakfastTime,
+    String? lunchTime,
+    String? dinnerTime,
     DateTime? createdAt,
     DateTime? updatedAt,
   }) {
@@ -74,6 +91,9 @@ class MealLog {
       breakfastNote: breakfastNote ?? this.breakfastNote,
       lunchNote: lunchNote ?? this.lunchNote,
       dinnerNote: dinnerNote ?? this.dinnerNote,
+      breakfastTime: breakfastTime ?? this.breakfastTime,
+      lunchTime: lunchTime ?? this.lunchTime,
+      dinnerTime: dinnerTime ?? this.dinnerTime,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );

--- a/lib/providers/meal_providers.dart
+++ b/lib/providers/meal_providers.dart
@@ -111,6 +111,47 @@ class MealNotifier extends AutoDisposeAsyncNotifier<void> {
       state = AsyncError(e, st);
     }
   }
+
+  Future<void> setBreakfastTime(DateTime date, String value) async {
+    final uid = ref.read(userIdProvider);
+    if (uid == null) return;
+    try {
+      await ref
+          .read(mealServiceProvider)
+          .setMealNote(
+            uid: uid,
+            date: date,
+            field: 'breakfastTime',
+            value: value,
+          );
+    } catch (e, st) {
+      state = AsyncError(e, st);
+    }
+  }
+
+  Future<void> setLunchTime(DateTime date, String value) async {
+    final uid = ref.read(userIdProvider);
+    if (uid == null) return;
+    try {
+      await ref
+          .read(mealServiceProvider)
+          .setMealNote(uid: uid, date: date, field: 'lunchTime', value: value);
+    } catch (e, st) {
+      state = AsyncError(e, st);
+    }
+  }
+
+  Future<void> setDinnerTime(DateTime date, String value) async {
+    final uid = ref.read(userIdProvider);
+    if (uid == null) return;
+    try {
+      await ref
+          .read(mealServiceProvider)
+          .setMealNote(uid: uid, date: date, field: 'dinnerTime', value: value);
+    } catch (e, st) {
+      state = AsyncError(e, st);
+    }
+  }
 }
 
 final mealNotifierProvider =

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -292,26 +292,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -348,10 +348,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   package_info_plus:
     dependency: "direct main"
     description:
@@ -561,10 +561,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -577,10 +577,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:


### PR DESCRIPTION
##  Closes #112

##  Änderungen

Zeiterfassung bei Mahlzeiten-Eingabe mit intelligenten Standardwerten.

### Model Erweiterungen

- **breakfastTime**, **lunchTime**, **dinnerTime** (String HH:mm format)
- Ergänzt in fromMap, toMap, copyWith

### Intelligente Standardzeiten

**Wochentage (Mo-Fr)**:
-  Frühstück: **06:30**
-  Mittag: **13:30**
-  Abend: **19:00**

**Wochenende (Sa-So)**:
-  Frühstück: **09:00**
-  Mittag: **14:00**
-  Abend: **19:00**

### UI Features

- **TimePicker Button** neben jedem Mahlzeiten-Textfeld
- Clock Icon () + aktuelle Zeit angezeigt
- showTimePicker Dialog zum Anpassen
- Sofortige Speicherung in Firestore
- Automatische Standard-Zeit basierend auf Mahlzeit-Typ & Datum

### Technisch

-  _getDefaultTime() Methode berechnet Defaults
-  _buildNoteFieldWithTime() Widget mit Row Layout
-  setBreakfastTime/setLunchTime/setDinnerTime in MealNotifier
-  State Management mit _breakfastTime/_lunchTime/_dinnerTime
-  Firestore Storage via setMealNote (generischer Ansatz)
-  flutter analyze: No issues

##  Business Value

- Genauere Datenerfassung für Essens-Analysen
- Basis für zeitbasierte KI-Empfehlungen
- Bessere Insights über Essenszeiten und -gewohnheiten
- User-Friendly mit intelligenten Defaults